### PR TITLE
Discourse migration

### DIFF
--- a/ckanext/pose_theme/base/helpers.py
+++ b/ckanext/pose_theme/base/helpers.py
@@ -470,9 +470,23 @@ def get_discourse_url():
     url = (
         config.get('ckanext.pose_theme.discourse_url')
         or config.get('discourse.url')
-        or 'https://community.civicdataecosystem.org'
+        or 'https://discuss.okfn.org'
     )
     return url.rstrip('/')
+
+
+def get_discourse_topics_path():
+    return config.get(
+        'ckanext.pose_theme.discourse_topics_path',
+        '/c/ckan/35/l/latest.json'
+    )
+
+
+def get_discourse_category_url():
+    return config.get(
+        'ckanext.pose_theme.discourse_category_url',
+        get_discourse_url() + '/c/ckan/35'
+    )
 
 
 _discourse_cache = {'topics': None, 'expires': 0}
@@ -516,9 +530,10 @@ def discourse_latest_topics(num=6):
             return _discourse_cache['topics'][:num]
 
         forum_url = get_discourse_url()
+        topics_path = get_discourse_topics_path()
         try:
             req = Request(
-                forum_url + '/latest.json',
+                forum_url + topics_path,
                 headers={'Accept': 'application/json', 'User-Agent': 'CKAN-pose-ecosystem-catalog/1.0'},
             )
             with urlopen(req, timeout=5) as response:

--- a/ckanext/pose_theme/base/helpers.py
+++ b/ckanext/pose_theme/base/helpers.py
@@ -539,15 +539,19 @@ def discourse_latest_topics(num=6):
             with urlopen(req, timeout=5) as response:
                 data = json.loads(response.read().decode('utf-8'))
 
-            # Build a username → avatar_url lookup from the top-level users list
+            # Build username → avatar_url and user_id → username lookups
             user_avatars = {}
+            user_id_to_username = {}
             for u in data.get('users', []):
                 template = u.get('avatar_template', '')
-                if template:
+                username = u.get('username', '')
+                if template and username:
                     avatar_url = template.replace('{size}', '40')
                     if avatar_url.startswith('/'):
                         avatar_url = forum_url + avatar_url
-                    user_avatars[u['username']] = avatar_url
+                    user_avatars[username] = avatar_url
+                if username and u.get('id'):
+                    user_id_to_username[u['id']] = username
 
             raw = data.get('topic_list', {}).get('topics', [])
             topics = []
@@ -556,6 +560,13 @@ def discourse_latest_topics(num=6):
                     continue
                 last_posted = t.get('last_posted_at') or t.get('created_at', '')
                 username = t.get('last_poster_username', '')
+
+                op_username = ''
+                for poster in t.get('posters', []):
+                    if 'Original Poster' in poster.get('description', ''):
+                        op_username = user_id_to_username.get(poster.get('user_id'), '')
+                        break
+
                 topics.append({
                     'title': t.get('title', ''),
                     'url': '{}/t/{}/{}'.format(forum_url, t.get('slug', ''), t.get('id', '')),
@@ -563,6 +574,8 @@ def discourse_latest_topics(num=6):
                     'relative_time': _relative_time(last_posted),
                     'last_poster': username,
                     'avatar_url': user_avatars.get(username, ''),
+                    'op_username': op_username,
+                    'op_avatar_url': user_avatars.get(op_username, '') if op_username != username else '',
                     'excerpt': t.get('excerpt', '').split('\n')[0][:120].strip(),
                 })
                 if len(topics) >= 20:  # cap fetch; cache the full set

--- a/ckanext/pose_theme/custom_themes/pose_theme/templates/scheming/package/read_extension.html
+++ b/ckanext/pose_theme/custom_themes/pose_theme/templates/scheming/package/read_extension.html
@@ -124,6 +124,7 @@
     {% block package_search_results_list %}
     {% endblock %}
 
+    {# TODO: re-enable discourse comments once helper is implemented for new discuss.okfn.org instance
     {% if pkg.discussions and pkg.discussions|string|lower not in ['false', '0', 'none', ''] %}
         <a class="btn btn-success" href="{{ pkg.url }}/discussions" target="_blank"><i class="fa fa-comments"></i> {{ _('Go to Discussions') }}</a>
     {% else %}
@@ -131,6 +132,7 @@
             {{ h.discourse_comments(pkg) }}
         {% endblock %}
     {% endif %}
+    #}
 
 {% endblock %}
 

--- a/ckanext/pose_theme/pose_custom_homepage/plugin/__init__.py
+++ b/ckanext/pose_theme/pose_custom_homepage/plugin/__init__.py
@@ -63,5 +63,5 @@ class PoseThemeHomepagePlugin(MixinPlugin):
             'version': helper.version_builder,
             'is_activity_enabled': helper.is_activity_enabled,
             'pose_theme_get_discourse_latest': helper.discourse_latest_topics,
-            'pose_theme_get_discourse_url': helper.get_discourse_url,
+            'pose_theme_get_discourse_url': helper.get_discourse_category_url,
         }

--- a/ckanext/pose_theme/pose_custom_homepage/templates/home/snippets/discourse_latest.html
+++ b/ckanext/pose_theme/pose_custom_homepage/templates/home/snippets/discourse_latest.html
@@ -18,11 +18,14 @@
         <ul class="discourse-topics-list">
           {% for topic in topics %}
             <li class="discourse-topic-item">
-              <span class="discourse-topic-icon">
-                {% if topic.avatar_url %}
-                  <img src="{{ topic.avatar_url }}" alt="{{ topic.last_poster }}'s avatar" class="discourse-avatar">
+              <span class="discourse-avatars">
+                {% if topic.op_avatar_url %}
+                  <img src="{{ topic.op_avatar_url }}" alt="{{ topic.op_username }}" class="discourse-avatar discourse-avatar-op" title="{{ topic.op_username }} (OP)">
+                  <img src="{{ topic.avatar_url }}" alt="{{ topic.last_poster }}" class="discourse-avatar discourse-avatar-reply" title="{{ topic.last_poster }} (latest reply)">
+                {% elif topic.avatar_url %}
+                  <img src="{{ topic.avatar_url }}" alt="{{ topic.last_poster }}" class="discourse-avatar discourse-avatar-single" title="{{ topic.last_poster }}">
                 {% else %}
-                  <i class="fa fa-user"></i>
+                  <span class="discourse-avatar-fallback"><i class="fa fa-user"></i></span>
                 {% endif %}
               </span>
               <div class="discourse-topic-body">
@@ -117,26 +120,45 @@
 .discourse-topic-item:last-child {
   border-bottom: none;
 }
-.discourse-topic-icon {
+.discourse-avatars {
   flex-shrink: 0;
-  width: 2rem;
+  display: flex;
+  align-items: center;
+  width: 3rem;
   height: 2rem;
+  position: relative;
+}
+.discourse-avatar {
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #fff;
+  position: absolute;
+}
+.discourse-avatar-single {
+  left: 0.5rem;
+}
+.discourse-avatar-op {
+  left: 0;
+  z-index: 1;
+}
+.discourse-avatar-reply {
+  left: 1.1rem;
+  z-index: 2;
+}
+.discourse-avatar-fallback {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background-color: #0089d1;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.85rem;
   color: #fff;
-  background-color: #0089d1;
-  margin-top: 0.15rem;
-  overflow: hidden;
-}
-.discourse-avatar {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 50%;
-  display: block;
+  font-size: 0.8rem;
+  position: absolute;
+  left: 0.5rem;
 }
 .discourse-topic-body {
   flex: 1;


### PR DESCRIPTION
This pull request updates how Discourse forum topics are integrated and displayed in the CKAN Pose Theme, including improvements to configuration flexibility, user avatar display, and helper functions. The main focus is on supporting the new Discourse instance and enhancing the display of discussion topics and user avatars.

**Discourse integration and configuration:**

* Changed the default Discourse URL from `community.civicdataecosystem.org` to `discuss.okfn.org`, and added new helper functions to allow configuration of the Discourse topics path and category URL via settings (`get_discourse_topics_path`, `get_discourse_category_url`).
* Updated the plugin to use the new `get_discourse_category_url` helper for retrieving the Discourse URL, ensuring correct linking to the intended category.

**Forum topics and avatar enhancements:**

* Improved the fetching and processing of Discourse topics by supporting a configurable topics path, building both username→avatar and user_id→username mappings, and extracting the original poster's (OP) username and avatar for each topic. [[1]](diffhunk://#diff-4c64e43c9cb9ce5905849a85a8dc33fd0fda0b510bf30ae6f94f858e9e2b25c9R533-R554) [[2]](diffhunk://#diff-4c64e43c9cb9ce5905849a85a8dc33fd0fda0b510bf30ae6f94f858e9e2b25c9R563-R578)
* Updated the homepage Discourse topics snippet to display both the original poster's and the latest replier's avatars side by side, with improved fallback and styling for avatars. [[1]](diffhunk://#diff-d68110b323cf541849c628545a847c44dc31aa1388324112bc2a998fe847732aL21-R28) [[2]](diffhunk://#diff-d68110b323cf541849c628545a847c44dc31aa1388324112bc2a998fe847732aL120-R161)

**Other changes:**

* Temporarily disabled Discourse comments in the package read extension template, pending an updated helper for the new Discourse instance.