### PR TITLE
Add SOTM badge and fix sotm_month persistence on edit

### DIFF
--- a/ckanext/pose_theme/custom_themes/pose_theme/site.yaml
+++ b/ckanext/pose_theme/custom_themes/pose_theme/site.yaml
@@ -296,7 +296,7 @@ dataset_fields:
   validators: ignore_missing
   form_placeholder: "e.g. 2026-03"
   help_text: "Set to YYYY-MM (e.g. 2026-03) to feature this site as Site of the Month for that month. Only one site should have a given month value."
-  form_snippet: null
+  form_snippet: scheming/form_snippets/hidden.html
 
 - field_name: topic_id
   label: Topic ID

--- a/ckanext/pose_theme/custom_themes/pose_theme/templates/scheming/form_snippets/hidden.html
+++ b/ckanext/pose_theme/custom_themes/pose_theme/templates/scheming/form_snippets/hidden.html
@@ -1,0 +1,2 @@
+{% import 'macros/form.html' as form %}
+{{ form.hidden(field.field_name, data[field.field_name]) }}

--- a/ckanext/pose_theme/custom_themes/pose_theme/templates/scheming/package/read_site.html
+++ b/ckanext/pose_theme/custom_themes/pose_theme/templates/scheming/package/read_site.html
@@ -115,12 +115,53 @@
       max-width: 100%;
       margin-bottom: 20px;
     }
-    
+
     .app-site-image {
       max-width: 100%;
       height: auto;
       border: 1px solid #ddd;
       border-radius: 4px;
+    }
+
+    .app-site-image-wrap {
+      position: relative;
+      overflow: hidden;
+      border-radius: 4px;
+      display: inline-block;
+      max-width: 100%;
+    }
+
+    .app-site-image-wrap .sotm-ribbon {
+      position: absolute;
+      top: 22px;
+      left: -36px;
+      width: 160px;
+      background: #d9534f;
+      color: #fff;
+      text-align: center;
+      padding: 6px 0 5px;
+      transform: rotate(-45deg);
+      transform-origin: center;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.22);
+      z-index: 2;
+      pointer-events: none;
+      line-height: 1.2;
+    }
+
+    .app-site-image-wrap .sotm-ribbon-label {
+      display: block;
+      font-size: 0.6rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      opacity: 0.85;
+    }
+
+    .app-site-image-wrap .sotm-ribbon-date {
+      display: block;
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
     }
     
     /* Visit application button */
@@ -283,13 +324,21 @@
                     {% endif %}
                     
                     {% if image_url %}
-                        {% if pkg.url %}
-                            <a href="{{ pkg.url }}" target="_blank">
+                        <div class="app-site-image-wrap">
+                            {% if pkg.url %}
+                                <a href="{{ pkg.url }}" target="_blank">
+                                    <img src="{{ h.get_image_url(image_url) }}" alt="{{ name }}" class="app-site-image">
+                                </a>
+                            {% else %}
                                 <img src="{{ h.get_image_url(image_url) }}" alt="{{ name }}" class="app-site-image">
-                            </a>
-                        {% else %}
-                            <img src="{{ h.get_image_url(image_url) }}" alt="{{ name }}" class="app-site-image">
-                        {% endif %}
+                            {% endif %}
+                            {% if pkg.sotm_month %}
+                                <div class="sotm-ribbon">
+                                    <span class="sotm-ribbon-label">{{ _('SOTM') }}</span>
+                                    <span class="sotm-ribbon-date">{{ h.render_datetime(pkg.sotm_month + '-01', date_format='%b %Y') }}</span>
+                                </div>
+                            {% endif %}
+                        </div>
                     {% endif %}
                 </div>
 

--- a/ckanext/pose_theme/custom_themes/pose_theme/templates/snippets/package_item.html
+++ b/ckanext/pose_theme/custom_themes/pose_theme/templates/snippets/package_item.html
@@ -59,6 +59,7 @@
 .badge-type--site      { background: rgba(51, 122, 183, 0.08) !important; color: #337ab7 !important; }
 .badge-type--showcase  { background: rgba(91, 192, 222, 0.10) !important; color: #1d8fad !important; }
 .badge-type--dataset   { background: rgba(92, 184, 92, 0.08)  !important; color: #3d8b3d !important; }
+.badge-sotm { font-size: 11px; padding: 3px 10px; border-radius: 12px; font-weight: 600; letter-spacing: 0.5px; display: inline-flex; align-items: center; margin-bottom: 8px; background: rgba(217, 83, 79, 0.08) !important; color: #d9534f !important; }
 </style>
   <li class="dataset-item">
     {% block content %}
@@ -78,6 +79,9 @@
           {% block heading_meta %}
             <div class="dataset-meta-badges">
               <span class="badge-type {{ type_class }}">{{ type_label }}</span>
+              {% if package.sotm_month %}
+                <span class="badge-sotm"><i class="fa fa-trophy" style="margin-right:4px;font-size:10px;"></i>{{ _('SOTM') }} {{ h.render_datetime(package.sotm_month + '-01', date_format='%b %Y') }}</span>
+              {% endif %}
               {% if package.get('state', '').startswith('draft') %}
                 <span class="label label-info">{{ _('Draft') }}</span>
               {% elif package.get('state', '').startswith('deleted') %}


### PR DESCRIPTION
## Summary

- Add SOTM ribbon overlay to screenshot on site read page when `sotm_month` is set
- Add SOTM badge pill next to the type label in dataset search results for sites with `sotm_month` set
- Fix `sotm_month` field being silently cleared whenever a site is edited — root cause was `form_snippet: null` meaning the field was never included in the form POST, causing CKAN's extras write-from-scratch logic to drop it on every update; fixed by replacing with a hidden input snippet that preserves the value

## Test plan

- [ ] Set `sotm_month` on a site, edit and save it — verify `sotm_month` is preserved
- [ ] Verify SOTM ribbon appears on site read page screenshot
- [ ] Verify SOTM badge appears next to "Site" pill in dataset search results
- [ ] Verify sites without `sotm_month` show no badge or ribbon

🤖 Generated with [Claude Code](https://claude.com/claude-code)