### PR TITLE
Fix site/extension resource step and optional resource support

### DIFF
--- a/ckanext/pose_theme/custom_themes/pose_theme/blueprint.py
+++ b/ckanext/pose_theme/custom_themes/pose_theme/blueprint.py
@@ -17,14 +17,24 @@ def dictionary_download(resource_id):
 datastore_dictionary.add_url_rule(u'/datastore/dictionary_download/<resource_id>', view_func=dictionary_download)
 
 
+_OPTIONAL_RESOURCE_TYPES = {
+    u'tool_resource': u'tool',
+    u'site_resource': u'site',
+    u'extension_resource': u'extension',
+}
+
+
 @datastore_dictionary.before_app_request
-def allow_tool_finish_without_resources():
+def allow_finish_without_resources():
     """
-    CKAN requires at least one resource when finishing dataset creation.
-    For the 'tool' type, resources are optional — intercept the resource
-    creation POST before CKAN's view runs and activate the dataset directly.
+    Resources are optional for tool/site/extension types.
+    Intercept the resource-creation POST and activate the dataset directly
+    when no resource data is provided.
     """
-    if request.endpoint != u'tool_resource.new' or request.method != u'POST':
+    pkg_type = _OPTIONAL_RESOURCE_TYPES.get(
+        request.endpoint.rsplit(u'.', 1)[0] if request.endpoint else u''
+    )
+    if not pkg_type or request.method != u'POST':
         return
     save_action = request.form.get(u'save')
     if save_action in (u'again', u'go-dataset', u'go-dataset-complete'):
@@ -51,11 +61,11 @@ def allow_tool_finish_without_resources():
             dict(context, allow_state_change=True),
             dict(data_dict, state=u'active')
         )
-        return h.redirect_to(u'tool.read', id=data_dict[u'name'])
+        return h.redirect_to(u'{}.read'.format(pkg_type), id=data_dict[u'name'])
     except (ObjectNotFound, NotAuthorized, ValidationError):
         return  # fall through to CKAN's normal handling
     except Exception:
-        log.exception(u'Unexpected error in allow_tool_finish_without_resources')
+        log.exception(u'Unexpected error in allow_finish_without_resources')
         return  # fall through to CKAN's normal handling
 
 
@@ -66,11 +76,17 @@ discourse_post_compat = Blueprint(u'discourse_post_compat', __name__)
 
 @discourse_post_compat.route(u'/site/<id>', methods=[u'POST'])
 def site_read_post(id):
+    if id == u'new':
+        from flask import current_app
+        return current_app.view_functions[u'site.new'](package_type=u'site')
     return redirect(url_for(u'site.read', id=id), 303)
 
 
 @discourse_post_compat.route(u'/extension/<id>', methods=[u'POST'])
 def extension_read_post(id):
+    if id == u'new':
+        from flask import current_app
+        return current_app.view_functions[u'extension.new'](package_type=u'extension')
     return redirect(url_for(u'extension.read', id=id), 303)
 
 


### PR DESCRIPTION
## Summary
- Fix `discourse_post_compat` blueprint hijacking `POST /site/new` and `POST /extension/new` (the `<id>` variable was matching `new`, intercepting dataset creation form submissions)
- Extend optional-resource logic to `site` and `extension` types alongside existing `tool` support — users can now finish creating a site/extension without adding a resource

## Test plan
- [ ] Create a new extension — "Next: Add Data" should proceed to resource page (not loop back to form)
- [ ] Create a new site — same as above
- [ ] On resource page, click "Finish" without adding a resource — package should be published
- [ ] On resource page, add a resource then "Finish" — resource saved, package published
- [ ] Discourse comment SSO flow on existing site/extension pages still redirects POST → GET correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)