### PR TITLE
Fix navbar container width inconsistency across pages

### DIFF
--- a/ckanext/pose_theme/pose_custom_homepage/public/css/layout3.css
+++ b/ckanext/pose_theme/pose_custom_homepage/public/css/layout3.css
@@ -1,4 +1,4 @@
-.container, .navbar-expand-lg .container, .navbar-fixed-top .container, .navbar-fixed-bottom .container {
+.homepage .container {
   max-width: 1360px !important;
 }
 .homepage [role=main] {


### PR DESCRIPTION
## Summary
- The homepage loaded `layout3.css` which set `.container { max-width: 1360px !important }` globally, affecting the navbar too
- Other pages used `theme.scss` values (`max-width: 1920px; width: 90%`), causing the navbar to appear wider on non-homepage pages
- Fix: scope the rule to `.homepage .container` so only the homepage content area is constrained; the navbar now uses consistent width everywhere

## Test plan
- [ ] Compare navbar width on homepage vs `/site`, `/extension`, `/dataset` — should be identical
- [ ] Homepage content layout still renders correctly at 1360px max-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)