### PR TITLE
Show user organizations on profile page

### DIFF
--- a/ckanext/pose_theme/base/helpers.py
+++ b/ckanext/pose_theme/base/helpers.py
@@ -91,6 +91,16 @@ def organization(num=12):
     return groups[:num]
 
 
+def get_user_organizations(user_id):
+    """Return organizations the given user belongs to."""
+    try:
+        return toolkit.get_action('organization_list_for_user')(
+            {}, {'id': user_id, 'permission': 'read', 'include_dataset_count': False}
+        )
+    except Exception:
+        return []
+
+
 def popular_datasets(num=6):
     """Return a list of popular datasets."""
     datasets = []

--- a/ckanext/pose_theme/custom_themes/pose_theme/assets/css/theme.css
+++ b/ckanext/pose_theme/custom_themes/pose_theme/assets/css/theme.css
@@ -541,3 +541,4 @@ section.showcases .slick-showcase .slick-arrow:hover {
   z-index: 0;
   border: 2px groove #6f6c7d14;
 }
+

--- a/ckanext/pose_theme/custom_themes/pose_theme/assets/css/theme.scss
+++ b/ckanext/pose_theme/custom_themes/pose_theme/assets/css/theme.scss
@@ -251,3 +251,4 @@ form.form-inline.form-select.lang-select {
   border-bottom: 1px solid #000!important;
   z-index: 10;
 }
+

--- a/ckanext/pose_theme/custom_themes/pose_theme/plugin.py
+++ b/ckanext/pose_theme/custom_themes/pose_theme/plugin.py
@@ -57,6 +57,7 @@ class PoseThemePlugin(plugins.SingletonPlugin):
             'pose_theme_tools': helper.tools,
             'pose_theme_featured_tools': helper.featured_tools,
             'pose_theme_recent_tools': helper.recent_tools,
+            'pose_theme_get_user_organizations': helper.get_user_organizations,
         }
 
     def get_commands(self):

--- a/ckanext/pose_theme/custom_themes/pose_theme/templates/user/read_base.html
+++ b/ckanext/pose_theme/custom_themes/pose_theme/templates/user/read_base.html
@@ -1,0 +1,18 @@
+{% ckan_extends %}
+
+{% block user_info %}
+{{ super() }}
+{% set orgs = h.pose_theme_get_user_organizations(user.id) %}
+{% if orgs %}
+<div class="info">
+  <dl>
+    <dt>{{ _('Organization') if orgs|length == 1 else _('Organizations') }}</dt>
+    <dd>
+      {% for org in orgs %}
+      <div><a href="{{ h.url_for('organization.read', id=org.name) }}">{{ org.display_name or org.title or org.name }}</a></div>
+      {% endfor %}
+    </dd>
+  </dl>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds `get_user_organizations` helper using CKAN's `organization_list_for_user` action
- Overrides `user/read_base.html` to display the user's organizations in the profile sidebar
- Each org appears on its own line as a link to the organization page
- Shows "Organization" (singular) or "Organizations" (plural) label depending on count

## Test plan
- [ ] Visit `/user/<username>` for a user belonging to one org — label reads "Organization" with a link
- [ ] Visit `/user/<username>` for a user belonging to multiple orgs — label reads "Organizations" with each on its own line
- [ ] Visit `/user/<username>` for a user with no org — section does not appear
- [ ] Org links navigate correctly to `/organization/<name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)