### PR TITLE
Serve homepage thumbnails from /assets/thumbnails/ instead of /dataset path

### DIFF
--- a/ckanext/pose_theme/base/helpers.py
+++ b/ckanext/pose_theme/base/helpers.py
@@ -92,6 +92,24 @@ def organization(num=12):
     return groups[:num]
 
 
+def get_thumbnail_url(pkg):
+    """Return a thumbnail URL for a package's first resource.
+
+    For uploaded files, returns a static-looking /assets/thumbnails/<id> URL
+    instead of the /dataset/<id>/resource/<id>/download/<file> path. Cloudflare
+    gates the /dataset path behind its bot challenge, so those images don't load
+    until the visitor is verified; /assets/* is served by the static-asset cache
+    rule with no challenge. External (http) resource URLs are returned as-is.
+    """
+    resources = (pkg.get('resources') if isinstance(pkg, dict) else None) or []
+    if not resources:
+        return None
+    res = resources[0]
+    if res.get('url_type') == 'upload':
+        return '/assets/thumbnails/' + res['id']
+    return res.get('url')
+
+
 def get_user_organizations(user_id):
     """Return organizations the given user belongs to."""
     try:

--- a/ckanext/pose_theme/base/helpers.py
+++ b/ckanext/pose_theme/base/helpers.py
@@ -106,7 +106,7 @@ def get_thumbnail_url(pkg):
         return None
     res = resources[0]
     if res.get('url_type') == 'upload':
-        return '/assets/thumbnails/' + res['id']
+        return toolkit.url_for('pose_thumbnails.thumbnail', resource_id=res['id'])
     return res.get('url')
 
 

--- a/ckanext/pose_theme/custom_themes/pose_theme/blueprint.py
+++ b/ckanext/pose_theme/custom_themes/pose_theme/blueprint.py
@@ -125,13 +125,27 @@ thumbnails = Blueprint(u'pose_thumbnails', __name__)
 
 @thumbnails.route(u'/assets/thumbnails/<resource_id>')
 def thumbnail(resource_id):
-    from ckan.plugins.toolkit import get_action, ObjectNotFound, NotAuthorized
+    from ckan.plugins.toolkit import abort, get_action, ObjectNotFound, NotAuthorized
     from ckan.views.resource import download as resource_download
+    from ckan.common import current_user
+    import ckan.model as model
+
+    # Use the real request user so authorized viewers of private packages are
+    # not falsely 404'd by an anonymous ({}) context.
+    context = {
+        u'model': model,
+        u'session': model.Session,
+        u'user': current_user.name,
+        u'auth_user_obj': current_user,
+    }
     try:
-        resource = get_action(u'resource_show')({}, {u'id': resource_id})
-        pkg = get_action(u'package_show')({}, {u'id': resource[u'package_id']})
+        resource = get_action(u'resource_show')(context, {u'id': resource_id})
+        # This alias is only for uploaded thumbnails; reject link/datastore
+        # resources so it can't be used to redirect to arbitrary URLs.
+        if resource.get(u'url_type') != u'upload':
+            return abort(404)
+        pkg = get_action(u'package_show')(context, {u'id': resource[u'package_id']})
     except (ObjectNotFound, NotAuthorized):
-        from ckan.plugins.toolkit import abort
         return abort(404)
     return resource_download(
         package_type=pkg.get(u'type', u'dataset'),

--- a/ckanext/pose_theme/custom_themes/pose_theme/blueprint.py
+++ b/ckanext/pose_theme/custom_themes/pose_theme/blueprint.py
@@ -112,6 +112,34 @@ def extension_read_post(id):
     return redirect(url_for(u'extension.read', id=id), 303)
 
 
+# Serve dataset-resource thumbnails under a static-looking /assets/thumbnails/
+# path instead of /dataset/<id>/resource/<id>/download/<file>. The homepage
+# thumbnails are dataset resources; on the /dataset/* path Cloudflare's bot
+# challenge gates them so they don't load until the visitor is verified.
+# /assets/* is covered by the static-asset cache rule (no challenge), so the
+# images load immediately. This is a URL alias — it streams/redirects to the
+# live resource, so there's no file duplication and it works for both local
+# and S3 (s3filestore) storage.
+thumbnails = Blueprint(u'pose_thumbnails', __name__)
+
+
+@thumbnails.route(u'/assets/thumbnails/<resource_id>')
+def thumbnail(resource_id):
+    from ckan.plugins.toolkit import get_action, ObjectNotFound, NotAuthorized
+    from ckan.views.resource import download as resource_download
+    try:
+        resource = get_action(u'resource_show')({}, {u'id': resource_id})
+        pkg = get_action(u'package_show')({}, {u'id': resource[u'package_id']})
+    except (ObjectNotFound, NotAuthorized):
+        from ckan.plugins.toolkit import abort
+        return abort(404)
+    return resource_download(
+        package_type=pkg.get(u'type', u'dataset'),
+        id=pkg[u'id'],
+        resource_id=resource_id,
+    )
+
+
 def get_blueprints():
-    return [datastore_dictionary, discourse_post_compat]
+    return [datastore_dictionary, discourse_post_compat, thumbnails]
  

--- a/ckanext/pose_theme/custom_themes/pose_theme/plugin.py
+++ b/ckanext/pose_theme/custom_themes/pose_theme/plugin.py
@@ -58,6 +58,7 @@ class PoseThemePlugin(plugins.SingletonPlugin):
             'pose_theme_featured_tools': helper.featured_tools,
             'pose_theme_recent_tools': helper.recent_tools,
             'pose_theme_get_user_organizations': helper.get_user_organizations,
+            'pose_theme_thumbnail_url': helper.get_thumbnail_url,
         }
 
     def get_commands(self):

--- a/ckanext/pose_theme/custom_themes/pose_theme/templates/scheming/package/read_site.html
+++ b/ckanext/pose_theme/custom_themes/pose_theme/templates/scheming/package/read_site.html
@@ -320,7 +320,7 @@
             <div class="app-site-sidebar">
                 <div class="app-site-image-container">
                     {% if not image_url %}
-                        {% set image_url = pkg.resources[0].url if pkg.resources else None %}
+                        {% set image_url = h.pose_theme_thumbnail_url(pkg) %}
                     {% endif %}
                     
                     {% if image_url %}

--- a/ckanext/pose_theme/custom_themes/pose_theme/templates/snippets/package_item.html
+++ b/ckanext/pose_theme/custom_themes/pose_theme/templates/snippets/package_item.html
@@ -13,7 +13,7 @@
 
 {% if not image_url %}
     {% if package.resources %}
-      {% set image_url = package.resources[0].url %}
+      {% set image_url = h.pose_theme_thumbnail_url(package) %}
     {% else %}
       {% set image_url = h.get_image_url(package.image_url) if package.image_url else None %}
     {% endif %}

--- a/ckanext/pose_theme/pose_custom_homepage/templates/home/snippets/site_of_month.html
+++ b/ckanext/pose_theme/pose_custom_homepage/templates/home/snippets/site_of_month.html
@@ -1,6 +1,6 @@
 {% set site = h.pose_theme_get_site_of_month() %}
 {% if site %}
-{% set image_url = site.resources[0].url if site.resources else None %}
+{% set image_url = h.pose_theme_thumbnail_url(site) %}
 <section class="section site-of-month">
   <div class="module-content">
     <div class="container">

--- a/ckanext/pose_theme/pose_custom_homepage/templates/snippets/pose_showcase_item.html
+++ b/ckanext/pose_theme/pose_custom_homepage/templates/snippets/pose_showcase_item.html
@@ -13,7 +13,7 @@
 {% set image_url = h.get_value_from_showcase_extras(showcase.extras, 'image_url') %}
 
 {% if not image_url %}
-    {% set image_url = showcase.resources[0].url if showcase.resources else None %}
+    {% set image_url = h.pose_theme_thumbnail_url(showcase) %}
 {% endif %}
 {% block showcase_item %}
 <div class="media-item">

--- a/ckanext/pose_theme/pose_custom_showcase/helpers.py
+++ b/ckanext/pose_theme/pose_custom_showcase/helpers.py
@@ -71,9 +71,13 @@ def get_recent_showcase_list(num=12):
 
 
 def get_image_url(image_url):
-    if 'https://' in image_url or 'http://' in image_url:
+    if not image_url:
         return image_url
-    print("***********************************", tk.h.url_for_static(image_url))
+    # Already-usable URLs (absolute http(s) or root-relative like
+    # /assets/thumbnails/<id>) are returned as-is; only bare filenames are
+    # resolved against the static assets directory.
+    if image_url.startswith(('http://', 'https://', '/')):
+        return image_url
     return tk.h.url_for_static(image_url)
 
 def get_package_showcase_list(package_id):

--- a/ckanext/pose_theme/pose_custom_showcase/templates/home/snippets/showcase_item.html
+++ b/ckanext/pose_theme/pose_custom_showcase/templates/home/snippets/showcase_item.html
@@ -13,7 +13,7 @@
 {% set image_url = h.get_value_from_showcase_extras(showcase.extras, 'image_url') %}
 
 {% if not image_url %}
-    {% set image_url = showcase.resources[0].url if showcase.resources else None %}
+    {% set image_url = h.pose_theme_thumbnail_url(showcase) %}
 {% endif %}
 
 {% block showcase_item %}

--- a/ckanext/pose_theme/pose_custom_showcase/templates/scheming/package/read_showcase.html
+++ b/ckanext/pose_theme/pose_custom_showcase/templates/scheming/package/read_showcase.html
@@ -69,7 +69,7 @@
         </h1>
           {% set image_url = h.get_value_from_showcase_extras(pkg.extras, 'image_url') %}
           {% if not image_url %}
-            {% set image_url = pkg.resources[0].url if pkg.resources else None %}
+            {% set image_url = h.pose_theme_thumbnail_url(pkg) %}
           {% endif %}
           <p class="ckanext-showcase-image-container">
             {% if pkg.url %}


### PR DESCRIPTION
## Problem
Homepage site/extension/showcase **thumbnails are dataset resources**, served from `/dataset/<id>/resource/<id>/download/<file>.jpg`. Cloudflare's bot challenge gates the `/dataset/*` path, so those images don't load until the visitor passes verification — the homepage cards render blank for unverified/first-time visitors.

## Approach
Serve the thumbnails from a static-looking **`/assets/thumbnails/<resource_id>`** path, which is covered by the existing Cloudflare static-asset cache rule (no bot challenge) and is off the `/dataset` path — per the requirement.

This is a **URL alias**, not a file copy:
- New blueprint route `/assets/thumbnails/<resource_id>` (`blueprint.py`) resolves the resource and delegates to CKAN's `resource.download` view — streams local uploads, redirects to S3 for `s3filestore`. No duplication, always current, works for both storage backends.
- New helper `pose_theme_thumbnail_url(pkg)` (`helpers.py`) returns `/assets/thumbnails/<id>` for uploaded first-resources; **external `http(s)` resource URLs pass through unchanged**.
- The 5 thumbnail snippets now call the helper instead of `resources[0].url`.
- `get_image_url` now passes root-relative URLs through untouched (so the assets path isn't re-resolved against the static dir); dropped a stray debug `print`.

## Requires (ops)
The Cloudflare static-asset cache/allow rule must cover `/assets/thumbnails/*` (same rule family already used for static assets). Without that exclusion the path still gets challenged.

## Test plan
- [ ] Restart CKAN, load homepage → featured site/showcase thumbnails render
- [ ] Inspect a thumbnail `src` → it's `/assets/thumbnails/<resource_id>`, not `/dataset/...`
- [ ] Open `/assets/thumbnails/<resource_id>` directly → image loads (local: streamed; S3: 302 to bucket)
- [ ] A site whose first resource is an external `http` URL → `src` is that external URL, unchanged
- [ ] Site-of-month + read pages (site/showcase) still render their images
- [ ] Confirm no `/assets/` route conflict with existing static handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)