### PR TITLE
Fix thumbnail route on S3 filestore (production)

### DIFF
--- a/ckanext/pose_theme/custom_themes/pose_theme/blueprint.py
+++ b/ckanext/pose_theme/custom_themes/pose_theme/blueprint.py
@@ -126,8 +126,8 @@ thumbnails = Blueprint(u'pose_thumbnails', __name__)
 @thumbnails.route(u'/assets/thumbnails/<resource_id>')
 def thumbnail(resource_id):
     from ckan.plugins.toolkit import abort, get_action, ObjectNotFound, NotAuthorized
-    from ckan.views.resource import download as resource_download
     from ckan.common import current_user
+    from flask import current_app
     import ckan.model as model
 
     # Use the real request user so authorized viewers of private packages are
@@ -147,8 +147,18 @@ def thumbnail(resource_id):
         pkg = get_action(u'package_show')(context, {u'id': resource[u'package_id']})
     except (ObjectNotFound, NotAuthorized):
         return abort(404)
-    return resource_download(
-        package_type=pkg.get(u'type', u'dataset'),
+
+    # Delegate to whichever resource-download view is actually registered so
+    # the active filestore serves the file. ckanext-s3filestore overrides the
+    # download route (endpoint 's3_resource.resource_download') to stream from
+    # S3; importing ckan.views.resource.download directly would bypass that and
+    # read from local disk, which fails when files live on S3.
+    pkg_type = pkg.get(u'type', u'dataset')
+    view = (current_app.view_functions.get(u's3_resource.resource_download')
+            or current_app.view_functions.get(u'{}_resource.download'.format(pkg_type))
+            or current_app.view_functions.get(u'resource.download'))
+    return view(
+        package_type=pkg_type,
         id=pkg[u'id'],
         resource_id=resource_id,
     )


### PR DESCRIPTION
## Problem
After #188 merged, production logged `[Errno 2] No such file or directory` for every `/assets/thumbnails/<id>` request, so homepage thumbnails stayed blank.

The route imported `ckan.views.resource.download` directly, which only reads from **local disk**. Production uses `ckanext-s3filestore`, where files live on S3. s3filestore serves downloads via its own view (endpoint `s3_resource.resource_download`) that streams from S3 — importing core's function bypassed that and hit a local path that doesn't exist. (Not reproducible locally, where storage is local disk.)

## Fix
Dispatch to whichever resource-download view is actually registered, so the active filestore serves the file:
```python
view = (view_functions.get('s3_resource.resource_download')      # s3filestore (prod)
        or view_functions.get('<type>_resource.download')        # core, typed
        or view_functions.get('resource.download'))              # core fallback
```
No coupling to a specific backend — s3filestore on prod, core locally.

## Context
Follow-up to #188, which was merged before this commit was pushed. The other review fixes from that branch (auth-context, non-upload rejection, `url_for`) already made it into #188. This PR carries only the S3 dispatch fix.

## Test plan (prod / S3)
- [ ] Deploy, then `curl -I https://ecosystem.ckan.org/assets/thumbnails/<resource_id>` → `200`, `Content-Type: image/webp` (no ENOENT in logs)
- [ ] Homepage featured site/showcase thumbnails render
- [ ] Local (local disk) still serves thumbnails via core view

🤖 Generated with [Claude Code](https://claude.com/claude-code)